### PR TITLE
Fix small bug in Ligating Loop when setting ObservationType to RGBD

### DIFF
--- a/sofa_env/scenes/ligating_loop/ligating_loop_env.py
+++ b/sofa_env/scenes/ligating_loop/ligating_loop_env.py
@@ -305,7 +305,7 @@ class LigatingLoopEnv(SofaEnv):
             self.observation_space = spaces.Box(low=0, high=255, shape=image_shape + (3,), dtype=np.uint8)
 
         # Color image and depth map
-        elif self.observation_type == ObservationType.RGBD:
+        elif observation_type == ObservationType.RGBD:
             self.observation_space = spaces.Box(low=0, high=255, shape=image_shape + (4,), dtype=np.uint8)
 
         else:


### PR DESCRIPTION
To reproduce run the following:
```
from sofa_env.base import RenderMode
from sofa_env.scenes.ligating_loop.ligating_loop_env import LigatingLoopEnv, ObservationType, ActionType

env = LigatingLoopEnv(
    observation_type=ObservationType.RGBD,
    render_mode=RenderMode.HUMAN,
    action_type=ActionType.CONTINUOUS,
    image_shape=(256, 256),
    frame_skip=1,
    time_step=0.1,
    settle_steps=50,
)
```