### PR TITLE
[TrajectoryRecorder] Add two features

### DIFF
--- a/sofa_env/wrappers/trajectory_recorder.py
+++ b/sofa_env/wrappers/trajectory_recorder.py
@@ -3,7 +3,7 @@ import numpy as np
 from copy import deepcopy
 from collections import defaultdict
 from pathlib import Path
-from typing import List, Optional, Union, Callable
+from typing import List, Optional, Union, Callable, Any
 import json
 
 
@@ -17,9 +17,12 @@ class TrajectoryRecorder(gym.Wrapper):
         after_step_callbacks: A list of callbacks that are executed after the environment's step function is called.
         before_reset_callbacks: A list of callbacks that are executed before the environment's reset function is called.
         after_reset_callbacks: A list of callbacks that are executed after the environment's reset function is called.
+        write_to_disk_callbacks: A list of callbacks that are executed when the episode is done and the trajectory data is written to the disk. Each callback function is called with the TrajectoryRecorder instance, the path to the trajectory directory, and the trajectory number.
         store_info: If True, the info dictionary of the environment is stored in the trajectory.
         metadata: A dictionary of metadata that is stored in the trajectory.
         save_compressed_keys: A list of keys that are saved as compressed numpy arrays.
+        only_record_successful_trajectories: If True, only successful trajectories are recorded, i.e. written to disk.
+        check_success_hook: A function that is called to determine whether the episode was successful or not; used when only_record_successful_trajectories is True. The function is called with the TrajectoryRecorder instance, the terminated flag, the truncated flag, and the info dictionary of the environment.
 
     Notes:
         Each trajectory is stored as a new subdirectory in the log directory.
@@ -36,9 +39,12 @@ class TrajectoryRecorder(gym.Wrapper):
         after_step_callbacks: Optional[List[Callable]] = None,
         before_reset_callbacks: Optional[List[Callable]] = None,
         after_reset_callbacks: Optional[List[Callable]] = None,
+        write_to_disk_callbacks: Optional[List[Callable[["TrajectoryRecorder", Path, int], None]]] = None,
         store_info: bool = False,
         metadata: Optional[dict] = None,
         save_compressed_keys: Optional[List[str]] = None,
+        only_record_successful_trajectories: bool = False,
+        check_success_hook: Optional[Callable[["TrajectoryRecorder", bool, bool, dict[str, Any]], bool]] = None,
     ):
         super().__init__(env)
         self.trajectory = defaultdict(list)
@@ -46,11 +52,19 @@ class TrajectoryRecorder(gym.Wrapper):
         self.after_step_callbacks = after_step_callbacks or []
         self.before_reset_callbacks = before_reset_callbacks or []
         self.after_reset_callbacks = after_reset_callbacks or []
+        self.write_to_disk_callbacks = write_to_disk_callbacks or []
         self.store_info = store_info
         self.log_dir = Path(log_dir)
         self.metadata = metadata
 
         self.save_compressed_keys = save_compressed_keys or []
+
+        self.only_record_successful_trajectories = only_record_successful_trajectories
+        if self.only_record_successful_trajectories:
+            if check_success_hook is None:
+                raise ValueError("check_success_hook must be provided if only_record_successful_trajectories is True.")
+            else:
+                self.check_success_hook = check_success_hook
 
         if not self.log_dir.is_dir():
             self.log_dir.mkdir(parents=True)
@@ -77,7 +91,13 @@ class TrajectoryRecorder(gym.Wrapper):
         # Store observation of T=t+1
         if terminated or truncated:
             self.trajectory["terminal_observation"].append(deepcopy(observation))
-            self.write_trajectory_to_disk()
+            if self.only_record_successful_trajectories:
+                if self.check_success_hook(self, terminated, truncated, info):
+                    self.write_trajectory_to_disk()
+                else:
+                    self.trajectory = defaultdict(list)
+            else:
+                self.write_trajectory_to_disk()
         else:
             self.trajectory["observation"].append(deepcopy(observation))
 
@@ -105,15 +125,19 @@ class TrajectoryRecorder(gym.Wrapper):
 
         # If there are none, start by appending _0 to the base name
         if len(existing_trajectories) == 0:
-            trajectory_name = base_name + "_0"
+            trajectory_number = 0
         else:
             # Otherwise, get the last trajectory and increment the number by 1
             last_trajectory = existing_trajectories[-1]
-            trajectory_name = base_name + f"_{int(last_trajectory.stem.split('_')[-1]) + 1}"
+            trajectory_number = int(last_trajectory.stem.split('_')[-1]) + 1
+        trajectory_name = base_name + f"_{trajectory_number}"
 
         # Create a directory for the trajectory
         trajectory_dir = self.log_dir / trajectory_name
         trajectory_dir.mkdir()
+
+        for callback in self.write_to_disk_callbacks:
+            callback(self, trajectory_dir, trajectory_number)
 
         # Remove the arrays that should be compressed from the trajectory dictionary
         for key in self.save_compressed_keys:


### PR DESCRIPTION
This adds two features to the `TrajectoryRecorder` class:

1. Filter for recording successful trajectories only
	The flag `only_record_successful_trajectories` can be set to only store successful trajectories on disk.
	In order to determine the outcome of an episode an additional `check_success_hook` callback function has to be supplied.
	The function is called with the `TrajectoryRecorder` instance, the `terminated` flag, the `truncated` flag, and the `info` dictionary of the environment.

2. Callbacks for when an episode is stored on disk
	Optionally, a list of `write_to_disk_callbacks` callbacks may be supplied.
	Each callback within this list will be executed when the episode is done and the trajectory data is written to the disk.
	Each callback is called with the `TrajectoryRecorder` instance, the `Path` to the trajectory directory, and the trajectory number (as `int`).
	I found this convenient for post-processing at the end of an episode where I had to store additional data for a recorded trajectory.