### PR TITLE
Use prebuilt SOFA

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -24,12 +24,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Download SOFA
         run: |
-          wget https://github.com/sofa-framework/sofa/releases/download/v22.12.00/SOFA_v22.12.00_Linux.zip
-          unzip SOFA_v22.12.00_Linux.zip
-          rm SOFA_v22.12.00_Linux.zip
+          wget https://github.com/sofa-framework/sofa/releases/download/v24.06.00/SOFA_v24.06.00_Linux.zip
+          unzip SOFA_v24.06.00_Linux.zip
+          rm SOFA_v24.06.00_Linux.zip
       - name: Preinstall PyOpenGL (https://github.com/mcfletch/pyopengl/issues/74)
         run: |
           pip install PyOpenGL
@@ -43,7 +43,7 @@ jobs:
           sed '/assert/d' original_setup.py > setup.py
       - name: Install dependencies
         run: |
-          export SOFA_ROOT=$(pwd)/SOFA_v22.12.00_Linux
+          export SOFA_ROOT=$(pwd)/SOFA_v24.06.00_Linux
           export SOFAPYTHON3_ROOT=$SOFA_ROOT/plugins/SofaPython3
           export SOFAPYTHON3_LIBS=$SOFAPYTHON3_ROOT/lib/python3/site-packages
           export PYTHON_PKG_PATH=$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
@@ -58,4 +58,4 @@ jobs:
         with:
           documentation_path: docs/source
           cache: true
-          python_version: 3.8
+          python_version: 3.10

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ __pycache__
 # Logs from recording demonstrations
 videos
 trajectories
+
+# The SOFA binaries
+SOFA

--- a/README.md
+++ b/README.md
@@ -4,42 +4,45 @@ This repository is part of "LapGym - An Open Source Framework for Reinforcement 
 See [LapGym](https://www.jmlr.org/papers/v24/23-0207.html) for the paper and [lap_gym](https://github.com/ScheiklP/lap_gym) for the top level repository.
 
 ## Getting Started
-### Option A: Using sofa_env as a package
-
-1. Make sure you are using Python 3.10, as the SOFA binaries are compiled for this version.
+### Getting the right python version
+1. Install [pyenv](https://github.com/pyenv/pyenv?tab=readme-ov-file#installation)
+2. Make sure you also installed the [build dependencies](https://github.com/pyenv/pyenv?tab=readme-ov-file#install-python-build-dependencies)
+3. Install python 3.10 through pyenv
 ```bash
-python3 --version
+pyenv install 3.10.15
 ```
-You can use conda, pyenv, or a virtual environment to manage your Python installation.
+4. Create a virtualenv with python 3.10 for sofa and activate it
 ```bash
-# Conda
-conda create -n sofa python=3.10
-conda activate sofa
-```
-
-2. You can then install the package directly from the repository with
-```bash
-pip install git+https://github.com/ScheiklP/sofa_env
+pyenv virtualenv 3.10.15 sofa
+pyenv activate sofa
 ```
 
-3. And then test the installation with
-```bash
-python3 -m sofa_env.scenes.controllable_object_example.controllable_env
-```
-
-### Option B: Modifying the environments
-If you want to modify the environments, you can clone the repository and install it in editable mode.
+### Option A (recommended): Using prebuilt SOFA binaries
+1. Clone this repository
 ```bash
 git clone https://github.com/ScheiklP/sofa_env.git 
+```
+
+2. Install the repository
+```bash
 cd sofa_env
-pip install -e .
+pip install .
+
+# If you want changes something in the code, install in editable mode
+# pip install -e .
+```
+
+3. Test the installation
+```bash
 python3 sofa_env/scenes/controllable_object_example/controllable_env.py
 ```
 
-### Option C: Manually setting up SOFA and SofaPython3
+### Option B (for the reckless): Manually setting up SOFA and SofaPython3
 If you want to set up SOFA and SofaPython3 manually, you can follow the [instructions](docs/source/setting_up_sofa.rst) to install SOFA and SofaPython3.
 And then install the `sofa_env` package with an environment variable to tell the setup script to skip the SOFA installation.
 ```bash
+git clone https://github.com/ScheiklP/sofa_env.git 
+cd sofa_env
 SKIP_SOFA=1 pip install -e .
 python3 sofa_env/scenes/controllable_object_example/controllable_env.py
 ```

--- a/README.md
+++ b/README.md
@@ -4,18 +4,43 @@ This repository is part of "LapGym - An Open Source Framework for Reinforcement 
 See [LapGym](https://www.jmlr.org/papers/v24/23-0207.html) for the paper and [lap_gym](https://github.com/ScheiklP/lap_gym) for the top level repository.
 
 ## Getting Started
-Tested under Ubuntu {18.04, 20.04, 22.04}, Fedora {36, 37}, and Windows (WSL).
-MacOS (on Intel and Apple Silicon) is technically supported, however
-it currently does not work due to a cmake problem in the pybind11 part of [SofaPython3](https://github.com/sofa-framework/SofaPython3).
+### Option A: Using sofa_env as a package
 
-1. Follow the [instructions](docs/source/setting_up_sofa.rst) to install SOFA and SofaPython3
-2. Install the `sofa_env` package
+1. Make sure you are using Python 3.10, as the SOFA binaries are compiled for this version.
 ```bash
+python3 --version
+```
+You can use conda, pyenv, or a virtual environment to manage your Python installation.
+```bash
+# Conda
+conda create -n sofa python=3.10
 conda activate sofa
+```
+
+2. You can then install the package directly from the repository with
+```bash
+pip install git+https://github.com/ScheiklP/sofa_env
+```
+
+3. And then test the installation with
+```bash
+python3 -m sofa_env.scenes.controllable_object_example.controllable_env
+```
+
+### Option B: Modifying the environments
+If you want to modify the environments, you can clone the repository and install it in editable mode.
+```bash
+git clone https://github.com/ScheiklP/sofa_env.git 
+cd sofa_env
 pip install -e .
+python3 sofa_env/scenes/controllable_object_example/controllable_env.py
 ```
-3. Test the installation
-```
+
+### Option C: Manually setting up SOFA and SofaPython3
+If you want to set up SOFA and SofaPython3 manually, you can follow the [instructions](docs/source/setting_up_sofa.rst) to install SOFA and SofaPython3.
+And then install the `sofa_env` package with an environment variable to tell the setup script to skip the SOFA installation.
+```bash
+SKIP_SOFA=1 pip install -e .
 python3 sofa_env/scenes/controllable_object_example/controllable_env.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ git clone https://github.com/ScheiklP/sofa_env.git
 2. Install the repository
 ```bash
 cd sofa_env
-pip install .
 
-# If you want changes something in the code, install in editable mode
 # pip install -e .
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,8 @@ setup(
         "open3d",
         "pytest",
         "filelock",
+        "pybind==2.9.1",
+        "scipy",
     ],
     python_requires=">=3.9",
     cmdclass={

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ INSTALL_COMMANDS = {
 
 class SOFAInstallCommand(install):
     """Customized install command to optionally install SOFA."""
+
     def run(self):
 
         # Check if manual sofa install environment variable (SKIP_SOFA) is set
@@ -48,8 +49,10 @@ class SOFAInstallCommand(install):
         # Proceed with normal installation
         install.run(self)
 
+
 class SOFADevelopCommand(develop):
     """Customized develop command to optionally install SOFA."""
+
     def run(self):
 
         # Check if manual sofa install environment variable (SKIP_SOFA) is set
@@ -63,60 +66,81 @@ class SOFADevelopCommand(develop):
         # Proceed with normal installation
         develop.run(self)
 
+
 def download_and_install_sofa():
-        # Check if the required Python version is installed
-        python_version = platform.python_version()
-        main_python_version = ".".join(python_version.split(".")[:2])
-        if main_python_version != PYTHON_VERSION:
-            raise Exception(f"Python version {PYTHON_VERSION} is required. Found {python_version}.")
+    # Check if the required Python version is installed
+    python_version = platform.python_version()
+    main_python_version = ".".join(python_version.split(".")[:2])
+    if main_python_version != PYTHON_VERSION:
+        raise Exception(
+            f"Python version {PYTHON_VERSION} is required. Found {python_version}."
+        )
 
-        # Check if the CPU architecture is x86_64
-        cpu_arch = platform.machine()
-        if cpu_arch != "x86_64":
-            raise Exception(f"CPU architecture x86_64 is required. Found {cpu_arch}. Please install SOFA manually.")
+    # Check if the CPU architecture is x86_64
+    cpu_arch = platform.machine()
+    if cpu_arch != "x86_64":
+        raise Exception(
+            f"CPU architecture x86_64 is required. Found {cpu_arch}. Please install SOFA manually."
+        )
 
-        # Determine platform and get the corresponding download URL
-        download_url = SOFA_DOWNLOAD_URLS[platform.system()]
-        file_name = download_url.split("/")[-1]
-        org_dir_name = file_name.split(".zip")[0]
-        sofa_dir_name = "SOFA"
+    # Determine platform and get the corresponding download URL
+    download_url = SOFA_DOWNLOAD_URLS[platform.system()]
+    file_name = download_url.split("/")[-1]
+    org_dir_name = file_name.split(".zip")[0]
+    sofa_dir_name = "SOFA"
 
-        which_command = "which" if platform.system() != "Windows" else "where"
+    which_command = "which" if platform.system() != "Windows" else "where"
 
-        # Assert that wget, unzip, and rm are available
-        if subprocess.run([which_command, "wget"]).returncode != 0:
-            raise Exception(f"wget is not installed. Please install it with {INSTALL_COMMANDS['wget'][platform.system()]}")
+    # Assert that wget, unzip, and rm are available
+    if subprocess.run([which_command, "wget"]).returncode != 0:
+        raise Exception(
+            f"wget is not installed. Please install it with {INSTALL_COMMANDS['wget'][platform.system()]}"
+        )
 
-        if subprocess.run([which_command, "unzip"]).returncode != 0:
-            raise Exception(f"unzip is not installed. Please install it with {INSTALL_COMMANDS['unzip'][platform.system()]}")
+    if subprocess.run([which_command, "unzip"]).returncode != 0:
+        raise Exception(
+            f"unzip is not installed. Please install it with {INSTALL_COMMANDS['unzip'][platform.system()]}"
+        )
 
-        # Download SOFA and extract it
-        logger.info(f"Downloading SOFA from {download_url}")
-        subprocess.run(["wget", download_url])
+    # Download SOFA and extract it
+    logger.info(f"Downloading SOFA from {download_url}")
+    subprocess.run(["wget", download_url])
 
-        logger.info(f"Extracting SOFA")
-        subprocess.run(["unzip", file_name])
-        os.remove(file_name)
+    logger.info(f"Extracting SOFA")
+    subprocess.run(["unzip", file_name])
+    os.remove(file_name)
 
-        # Move extracted directory to "SOFA", overwrite if necessary
-        if os.path.exists(sofa_dir_name):
-            shutil.rmtree(sofa_dir_name)
-        os.rename(org_dir_name, sofa_dir_name)
+    # Move extracted directory to "SOFA", overwrite if necessary
+    if os.path.exists(sofa_dir_name):
+        shutil.rmtree(sofa_dir_name)
+    os.rename(org_dir_name, sofa_dir_name)
 
-        # Set environment variables
-        sofa_root = os.path.abspath(sofa_dir_name)
-        sofa_python_root = os.path.join(sofa_root, "plugins", "SofaPython3")
-        sofa_python_libs = os.path.join(sofa_python_root, "lib", "python3", "site-packages")
-        python_pkg_path = subprocess.check_output(['python3', '-c', 'import sysconfig; print(sysconfig.get_paths()["purelib"])']).strip().decode('utf-8')
+    # Set environment variables
+    sofa_root = os.path.abspath(sofa_dir_name)
+    sofa_python_root = os.path.join(sofa_root, "plugins", "SofaPython3")
+    sofa_python_libs = os.path.join(sofa_python_root, "lib", "python3", "site-packages")
+    python_pkg_path = (
+        subprocess.check_output(
+            [
+                "python3",
+                "-c",
+                'import sysconfig; print(sysconfig.get_paths()["purelib"])',
+            ]
+        )
+        .strip()
+        .decode("utf-8")
+    )
 
-        # Check if the SOFA Python libraries are already installed, and remove them if necessary,
-        # then create symbolic links.
-        for lib in ["Sofa", "SofaRuntime", "SofaTypes", "splib"]:
-            if os.path.exists(os.path.join(python_pkg_path, lib)):
-                os.remove(os.path.join(python_pkg_path, lib))
-            os.symlink(os.path.join(sofa_python_libs, lib), os.path.join(python_pkg_path, lib))
+    # Check if the SOFA Python libraries are already installed, and remove them if necessary,
+    # then create symbolic links.
+    for lib in ["Sofa", "SofaRuntime", "SofaTypes", "splib"]:
+        if os.path.exists(os.path.join(python_pkg_path, lib)):
+            os.remove(os.path.join(python_pkg_path, lib))
+        os.symlink(
+            os.path.join(sofa_python_libs, lib), os.path.join(python_pkg_path, lib)
+        )
 
-        logger.info(f"SOFA installed successfully at {sofa_root}")
+    logger.info(f"SOFA installed successfully at {sofa_root}")
 
 
 setup(
@@ -148,13 +172,11 @@ setup(
         "open3d",
         "pytest",
         "filelock",
-        "pybind==2.9.1",
         "scipy",
     ],
     python_requires=">=3.9",
     cmdclass={
         "install": SOFAInstallCommand,
-        "develop": SOFADevelopCommand
+        "develop": SOFADevelopCommand,
     },
 )
-

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,130 @@
-import importlib.util
+import os
+import subprocess
+import platform
+import logging
+import shutil
 
 from setuptools import setup
+from setuptools.command.install import install
+from setuptools.command.develop import develop
 
-SOFA_MODULE = "Sofa"
-assert importlib.util.find_spec(SOFA_MODULE), f"Could not find {SOFA_MODULE} module. \n Please install SOFA with the SofaPython3 plugin."
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+SOFA_DOWNLOAD_URLS = {
+    "Linux": "https://github.com/sofa-framework/sofa/releases/download/v24.06.00/SOFA_v24.06.00_Linux.zip",
+    "Darwin": "https://github.com/sofa-framework/sofa/releases/download/v24.06.00/SOFA_v24.06.00_MacOS.zip",
+    "Windows": "https://github.com/sofa-framework/sofa/releases/download/v24.06.00/SOFA_v24.06.00_Win64.zip",
+}
+
+PYTHON_VERSION = "3.10"
+
+INSTALL_COMMANDS = {
+    "wget": {
+        "Linux": "sudo apt install wget",
+        "Darwin": "brew install wget",
+        "Windows": "choco install wget",
+    },
+    "unzip": {
+        "Linux": "sudo apt install unzip",
+        "Darwin": "brew install unzip",
+        "Windows": "choco install unzip",
+    },
+}
+
+
+class SOFAInstallCommand(install):
+    """Customized install command to optionally install SOFA."""
+    def run(self):
+
+        # Check if manual sofa install environment variable (SKIP_SOFA) is set
+        skip_sofa = os.environ.get("SKIP_SOFA", "0")
+
+        if skip_sofa == "1":
+            logger.warning("Skipping SOFA installation. Make sure to install SOFA manually.")
+        else:
+            download_and_install_sofa()
+
+        # Proceed with normal installation
+        install.run(self)
+
+class SOFADevelopCommand(develop):
+    """Customized develop command to optionally install SOFA."""
+    def run(self):
+
+        # Check if manual sofa install environment variable (SKIP_SOFA) is set
+        skip_sofa = os.environ.get("SKIP_SOFA", "0")
+
+        if skip_sofa == "1":
+            logger.warning("Skipping SOFA installation. Make sure to install SOFA manually.")
+        else:
+            download_and_install_sofa()
+
+        # Proceed with normal installation
+        develop.run(self)
+
+def download_and_install_sofa():
+        # Check if the required Python version is installed
+        python_version = platform.python_version()
+        main_python_version = ".".join(python_version.split(".")[:2])
+        if main_python_version != PYTHON_VERSION:
+            raise Exception(f"Python version {PYTHON_VERSION} is required. Found {python_version}.")
+
+        # Check if the CPU architecture is x86_64
+        cpu_arch = platform.machine()
+        if cpu_arch != "x86_64":
+            raise Exception(f"CPU architecture x86_64 is required. Found {cpu_arch}. Please install SOFA manually.")
+
+        # Determine platform and get the corresponding download URL
+        download_url = SOFA_DOWNLOAD_URLS[platform.system()]
+        file_name = download_url.split("/")[-1]
+        org_dir_name = file_name.split(".zip")[0]
+        sofa_dir_name = "SOFA"
+
+        which_command = "which" if platform.system() != "Windows" else "where"
+
+        # Assert that wget, unzip, and rm are available
+        if subprocess.run([which_command, "wget"]).returncode != 0:
+            raise Exception(f"wget is not installed. Please install it with {INSTALL_COMMANDS['wget'][platform.system()]}")
+
+        if subprocess.run([which_command, "unzip"]).returncode != 0:
+            raise Exception(f"unzip is not installed. Please install it with {INSTALL_COMMANDS['unzip'][platform.system()]}")
+
+        # Download SOFA and extract it
+        logger.info(f"Downloading SOFA from {download_url}")
+        subprocess.run(["wget", download_url])
+
+        logger.info(f"Extracting SOFA")
+        subprocess.run(["unzip", file_name])
+        os.remove(file_name)
+
+        # Move extracted directory to "SOFA", overwrite if necessary
+        if os.path.exists(sofa_dir_name):
+            shutil.rmtree(sofa_dir_name)
+        os.rename(org_dir_name, sofa_dir_name)
+
+        # Set environment variables
+        sofa_root = os.path.abspath(sofa_dir_name)
+        sofa_python_root = os.path.join(sofa_root, "plugins", "SofaPython3")
+        sofa_python_libs = os.path.join(sofa_python_root, "lib", "python3", "site-packages")
+        python_pkg_path = subprocess.check_output(['python3', '-c', 'import sysconfig; print(sysconfig.get_paths()["purelib"])']).strip().decode('utf-8')
+
+        # Check if the SOFA Python libraries are already installed, and remove them if necessary,
+        # then create symbolic links.
+        for lib in ["Sofa", "SofaRuntime", "SofaTypes", "splib"]:
+            if os.path.exists(os.path.join(python_pkg_path, lib)):
+                os.remove(os.path.join(python_pkg_path, lib))
+            os.symlink(os.path.join(sofa_python_libs, lib), os.path.join(python_pkg_path, lib))
+
+        logger.info(f"SOFA installed successfully at {sofa_root}")
+
 
 setup(
     name="sofa_env",
-    version="0.0.1",
-    description="OpenAI Gym wrapper for SOFA simulations",
+    version="1.0.0",
+    description="Gymnasium wrapper for SOFA simulations",
     author="Paul Maria Scheikl",
-    author_email="paul.scheikl@kit.edu",
+    author_email="pscheik1@jhu.edu",
     packages=["sofa_env"],
     install_requires=[
         "numpy",
@@ -36,4 +150,9 @@ setup(
         "filelock",
     ],
     python_requires=">=3.9",
+    cmdclass={
+        "install": SOFAInstallCommand,
+        "develop": SOFADevelopCommand
+    },
 )
+

--- a/sofa_env/base.py
+++ b/sofa_env/base.py
@@ -79,11 +79,6 @@ class SofaEnv(gym.Env, metaclass=abc.ABCMeta):
         render_framework: RenderFramework = RenderFramework.PYGLET,
         suppress_sofa_init_messages: bool = False,
     ) -> None:
-        if "SOFA_ROOT" not in os.environ:
-            raise RuntimeError("Missing SOFA_ROOT in your environment variables.")
-
-        if "SOFAPYTHON3_ROOT" not in os.environ:
-            raise RuntimeError("Missing SOFAPYTHON3_ROOT in your environment variables.")
 
         # HUMAN -> create and show a pyglet window
         # HEADLESS -> no pyglet window created

--- a/sofa_env/base.py
+++ b/sofa_env/base.py
@@ -221,7 +221,10 @@ class SofaEnv(gym.Env, metaclass=abc.ABCMeta):
         if hasattr(self, "sofa_simulation"):
             self.sofa_simulation.unload(self._sofa_root_node)
         if hasattr(self, "_window") and self._window is not None:
-            self._window.close()
+            if self.render_framework == RenderFramework.PYGLET:
+                self._window.close()
+            else:
+                self.pygame.quit()
 
     def _init_sim(self) -> None:
         """Initializes simulation by creating the scene graph."""

--- a/sofa_env/scenes/controllable_object_example/controllable_env.py
+++ b/sofa_env/scenes/controllable_object_example/controllable_env.py
@@ -60,6 +60,7 @@ if __name__ == "__main__":
     env = ControllableEnv(
         scene_path=scene_description,
         render_mode=RenderMode.HUMAN,
+        render_framework=RenderFramework.PYGAME,
     )
 
     env.reset()


### PR DESCRIPTION
The SOFA binaries are now compiled with python 3.10, so we make the switch to using the binaries over compiling SOFA manually.

Test for
- [x] Ubuntu 24.04
- [x] Ubuntu 22.04
- [x] Ubuntu 20.04
- [x] Windows WSL
- [x] MacOS